### PR TITLE
Retrofitting: Individual Tests :- 31 Tests Parameterised

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestQuotaUsage.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestQuotaUsage.java
@@ -20,26 +20,43 @@ package org.apache.hadoop.fs;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Enclosed.class)
 public class TestQuotaUsage {
 
-  // check the empty constructor correctly initialises the object
-  @Test
-  public void testConstructorEmpty() {
-    QuotaUsage quotaUsage = new QuotaUsage.Builder().build();
-    assertEquals("getQuota", -1, quotaUsage.getQuota());
-    assertEquals("getSpaceConsumed", 0, quotaUsage.getSpaceConsumed());
-    assertEquals("getSpaceQuota", -1, quotaUsage.getSpaceQuota());
-  }
+  @RunWith(Parameterized.class)
+  public static class TheParameterizedPart {
+    @Parameterized.Parameter(value = 0)
+    public long fileAndDirCount;
+    @Parameterized.Parameter(value = 1)
+    public long quota;
+    @Parameterized.Parameter(value = 2)
+    public long spaceConsumed;
+    @Parameterized.Parameter(value = 3)
+    public long spaceQuota;
+    @Parameterized.Parameter(value = 4)
+    public long SSDQuota;
 
+    @Parameterized.Parameters
+    public static Collection<Object> testData() {
+      Object[][] data = new Object[][] { {22222, 44444, 55555, 66666, 300000},
+                                         {22222, 3, 11111, 7, 444444},
+                                         {-1, 1, -1, 1, -1},
+                                         {222255555, 222256578, 1073741825, 1, 5}
+       };
+      return Arrays.asList(data);
+    }
+
+  // PUTs #19
   // check the full constructor with quota information
   @Test
   public void testConstructorWithQuota() {
-    long fileAndDirCount = 22222;
-    long quota = 44444;
-    long spaceConsumed = 55555;
-    long spaceQuota = 66666;
-
     QuotaUsage quotaUsage = new QuotaUsage.Builder().
         fileAndDirectoryCount(fileAndDirCount).quota(quota).
         spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).build();
@@ -51,11 +68,10 @@ public class TestQuotaUsage {
     assertEquals("getSpaceQuota", spaceQuota, quotaUsage.getSpaceQuota());
   }
 
+  // PUTs #20
   // check the constructor with quota information
   @Test
   public void testConstructorNoQuota() {
-    long spaceConsumed = 11111;
-    long fileAndDirCount = 22222;
     QuotaUsage quotaUsage = new QuotaUsage.Builder().
         fileAndDirectoryCount(fileAndDirCount).
         spaceConsumed(spaceConsumed).build();
@@ -67,66 +83,33 @@ public class TestQuotaUsage {
     assertEquals("getSpaceQuota", -1, quotaUsage.getSpaceQuota());
   }
 
-  // check the header
-  @Test
-  public void testGetHeader() {
-    String header = "       QUOTA       REM_QUOTA     SPACE_QUOTA "
-        + "REM_SPACE_QUOTA ";
-    assertEquals(header, QuotaUsage.getHeader());
-  }
-
+  // PUTs #21
   // check the toString method with quotas
   @Test
   public void testToStringWithQuota() {
-    long fileAndDirCount = 55555;
-    long quota = 44444;
-    long spaceConsumed = 55555;
-    long spaceQuota = 66665;
-
     QuotaUsage quotaUsage = new QuotaUsage.Builder().
         fileAndDirectoryCount(fileAndDirCount).quota(quota).
         spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).build();
-    String expected ="       44444          -11111           66665" +
-        "           11110 ";
+    String expected = String.format(QuotaUsage.QUOTA_STRING_FORMAT + QuotaUsage.SPACE_QUOTA_STRING_FORMAT,
+              quota, (quota-fileAndDirCount), spaceQuota, (spaceQuota - spaceConsumed));
     assertEquals(expected, quotaUsage.toString());
   }
 
+  // PUTs #22
   // check the toString method with quotas
   @Test
   public void testToStringNoQuota() {
     QuotaUsage quotaUsage = new QuotaUsage.Builder().
-        fileAndDirectoryCount(1234).build();
+        fileAndDirectoryCount(fileAndDirCount).build();
     String expected = "        none             inf            none"
         + "             inf ";
     assertEquals(expected, quotaUsage.toString());
   }
 
-  // check the toString method with quotas
-  @Test
-  public void testToStringHumanWithQuota() {
-    long fileAndDirCount = 222255555;
-    long quota = 222256578;
-    long spaceConsumed = 1073741825;
-    long spaceQuota = 1;
-
-    QuotaUsage quotaUsage = new QuotaUsage.Builder().
-        fileAndDirectoryCount(fileAndDirCount).quota(quota).
-        spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).build();
-    String expected = "     212.0 M            1023               1 "
-        + "           -1 G ";
-    assertEquals(expected, quotaUsage.toString(true));
-  }
-
+  // PUTs #23
   // check the equality
   @Test
   public void testCompareQuotaUsage() {
-    long fileAndDirCount = 222255555;
-    long quota = 222256578;
-    long spaceConsumed = 1073741825;
-    long spaceQuota = 1;
-    long SSDspaceConsumed = 100000;
-    long SSDQuota = 300000;
-
     QuotaUsage quotaUsage1 = new QuotaUsage.Builder().
         fileAndDirectoryCount(fileAndDirCount).quota(quota).
         spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).
@@ -142,5 +125,43 @@ public class TestQuotaUsage {
         build();
 
     assertEquals(quotaUsage1, quotaUsage2);
+  }
+  }
+
+
+  public static class NotParameterizedPart {
+  // check the empty constructor correctly initialises the object
+  @Test
+  public void testConstructorEmpty() {
+    QuotaUsage quotaUsage = new QuotaUsage.Builder().build();
+    assertEquals("getQuota", -1, quotaUsage.getQuota());
+    assertEquals("getSpaceConsumed", 0, quotaUsage.getSpaceConsumed());
+    assertEquals("getSpaceQuota", -1, quotaUsage.getSpaceQuota());
+  }
+
+  // check the header
+  @Test
+  public void testGetHeader() {
+    String header = "       QUOTA       REM_QUOTA     SPACE_QUOTA "
+        + "REM_SPACE_QUOTA ";
+    assertEquals(header, QuotaUsage.getHeader());
+  }
+
+  // check the toString method with quotas
+  // Can be removed #1, covered in PUTs #21
+  @Test
+  public void testToStringHumanWithQuota() {
+    long fileAndDirCount = 222255555;
+    long quota = 222256578;
+    long spaceConsumed = 1073741825;
+    long spaceQuota = 1;
+
+    QuotaUsage quotaUsage = new QuotaUsage.Builder().
+        fileAndDirectoryCount(fileAndDirCount).quota(quota).
+        spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).build();
+    String expected = "     212.0 M            1023               1 "
+        + "           -1 G ";
+    assertEquals(expected, quotaUsage.toString(true));
+  }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestArrayWritable.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestArrayWritable.java
@@ -23,26 +23,46 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 
 /** Unit tests for ArrayWritable */
+@RunWith(Enclosed.class)
 public class TestArrayWritable {
   static class TextArrayWritable extends ArrayWritable {
     public TextArrayWritable() {
       super(Text.class);
     }
   }
-	
+
+@RunWith(Parameterized.class)
+public static class TheParameterizedPart {
+    @Parameterized.Parameter(value = 0)
+    public Text[] elements;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> textData() {
+        Text[][][] data = new Text[][][] { {{new Text("zero"), new Text("one"), new Text("two")} },
+                { {new Text("zero"), new Text("one")} },
+                { {new Text("")} },
+                { {new Text("$@#*(@&")} }
+        };
+        return Arrays.asList(data);
+    }
+
   /**
    * If valueClass is undefined, readFields should throw an exception indicating
-   * that the field is null. Otherwise, readFields should succeed.	
+   * that the field is null. Otherwise, readFields should succeed.
    */
+  // PUTs #1
   @Test
   public void testThrowUndefinedValueException() throws IOException {
-    // Get a buffer containing a simple text array
-    Text[] elements = {new Text("zero"), new Text("one"), new Text("two")};
     TextArrayWritable sourceArray = new TextArrayWritable();
     sourceArray.set(elements);
 
@@ -62,25 +82,27 @@ public class TestArrayWritable {
       assertEquals(destElements[i],elements[i]);
     }
   }
-  
+
  /**
-  * test {@link ArrayWritable} toArray() method 
+  * test {@link ArrayWritable} toArray() method
   */
+ // PUTs #2
  @Test
   public void testArrayWritableToArray() {
-    Text[] elements = {new Text("zero"), new Text("one"), new Text("two")};
     TextArrayWritable arrayWritable = new TextArrayWritable();
     arrayWritable.set(elements);
     Object array = arrayWritable.toArray();
-  
+
     assertTrue("TestArrayWritable testArrayWritableToArray error!!! ", array instanceof Text[]);
     Text[] destElements = (Text[]) array;
-  
+
     for (int i = 0; i < elements.length; i++) {
       assertEquals(destElements[i], elements[i]);
     }
   }
-  
+  }
+
+  public static class NotParameterizedPart {
   /**
    * test {@link ArrayWritable} constructor with null
    */
@@ -96,10 +118,10 @@ public class TestArrayWritable {
   public void testArrayWritableStringConstructor() {
     String[] original = { "test1", "test2", "test3" };
     ArrayWritable arrayWritable = new ArrayWritable(original);
-    assertEquals("testArrayWritableStringConstructor class error!!!", 
+    assertEquals("testArrayWritableStringConstructor class error!!!",
         Text.class, arrayWritable.getValueClass());
     assertArrayEquals("testArrayWritableStringConstructor toString error!!!",
       original, arrayWritable.toStrings());
   }
-  
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -108,7 +108,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 /** Unit tests for RPC. */
-// Potential Bug #2 -> All tests won't run with error -> conf is not set
 @SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class TestRPC extends TestRpcBase {
@@ -363,6 +362,7 @@ public class TestRPC extends TestRpcBase {
               { 999, 99999 , 5},
 //                                       { 0, 5 , 1}, // fails -> java.lang.IllegalArgumentException
 //                                       { 1, -1 , 1} // fails -> java.lang.IllegalArgumentException
+// todo add assumes for above
       };
 
       return Arrays.asList(data);
@@ -721,8 +721,7 @@ public class TestRPC extends TestRpcBase {
     assertEquals(numberOfStopProxy, invocationHandler.getCloseCalled());
   }
 
-  // Potential Bug #3 :- test failure  -> java.lang.ClassCastException: org.apache.hadoop.ipc.WritableRpcEngine$Invoker
-  // cannot be cast to org.apache.hadoop.ipc.TestRPC$StoppedInvocationHandler
+  // PUTs #31
   @Test
   public void testWrappedStopProxy() throws IOException {
     StoppedProtocol wrappedProxy = RPC.getProxy(StoppedProtocol.class,
@@ -733,9 +732,10 @@ public class TestRPC extends TestRpcBase {
     StoppedProtocol proxy = (StoppedProtocol) RetryProxy.create(
         StoppedProtocol.class, wrappedProxy, RetryPolicies.RETRY_FOREVER);
 
-    assertEquals(0, invocationHandler.getCloseCalled());
-    RPC.stopProxy(proxy);
-    assertEquals(1, invocationHandler.getCloseCalled());
+    for(int i=0;i<numberOfStopProxy;i++) {
+              RPC.stopProxy(proxy);
+            }
+    assertEquals(numberOfStopProxy, invocationHandler.getCloseCalled());
   }
 
   @Test
@@ -795,6 +795,7 @@ public class TestRPC extends TestRpcBase {
   /**
    * Test that server.stop() properly stops all threads
    */
+   // todo Fix, find a way to remove threadsBefore for multiple test executions
   @Test
   public void testStopsAllThreads() throws IOException, InterruptedException {
     Server server;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.test.Whitebox;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -73,6 +75,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -105,7 +108,9 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 /** Unit tests for RPC. */
+// Potential Bug #2 -> All tests won't run with error -> conf is not set
 @SuppressWarnings("deprecation")
+@RunWith(Parameterized.class)
 public class TestRPC extends TestRpcBase {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestRPC.class);
@@ -133,7 +138,7 @@ public class TestRPC extends TestRpcBase {
 
   public static class TestImpl implements TestProtocol {
     int fastPingCounter = 0;
-    
+
     @Override
     public long getProtocolVersion(String protocol, long clientVersion) {
       return TestProtocol.versionID;
@@ -147,7 +152,7 @@ public class TestRPC extends TestRpcBase {
 
     @Override
     public void ping() {}
-    
+
     @Override
     public void sleep(long delay) throws InterruptedException {
       Thread.sleep(delay);
@@ -344,6 +349,26 @@ public class TestRPC extends TestRpcBase {
 
   }
 
+    @Parameterized.Parameter(value = 0)
+    public int testNumHandler1; //  number of method handler threads to run
+    @Parameterized.Parameter(value = 1)
+    public int testNumHandler2; //  number of method handler threads to run
+    @Parameterized.Parameter(value = 2)
+    public int numberOfStopProxy; //  number of method handler threads to run
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+      Object[][] data = new Object[][] { { 1, 1 , 0},
+              { 3, 4 , 1},
+              { 999, 99999 , 5},
+//                                       { 0, 5 , 1}, // fails -> java.lang.IllegalArgumentException
+//                                       { 1, -1 , 1} // fails -> java.lang.IllegalArgumentException
+      };
+
+      return Arrays.asList(data);
+    }
+
+  // PUTs #24
   @Test
   public void testConfRpc() throws IOException {
     Server server = newServerBuilder(conf)
@@ -361,15 +386,15 @@ public class TestRPC extends TestRpcBase {
     assertEquals(confReaders, server.getNumReaders());
 
     server = newServerBuilder(conf)
-        .setNumHandlers(1).setnumReaders(3).setQueueSizePerHandler(200)
+        .setNumHandlers(testNumHandler1).setnumReaders(confReaders).setQueueSizePerHandler(confQ)
         .setVerbose(false).build();
 
-    assertEquals(3, server.getNumReaders());
-    assertEquals(200, server.getMaxQueueSize());
+    assertEquals(confReaders, server.getNumReaders());
+    assertEquals(testNumHandler1*confQ, server.getMaxQueueSize());
 
-    server = newServerBuilder(conf).setQueueSizePerHandler(10)
-        .setNumHandlers(2).setVerbose(false).build();
-    assertEquals(2 * 10, server.getMaxQueueSize());
+    server = newServerBuilder(conf).setQueueSizePerHandler(confQ)
+        .setNumHandlers(testNumHandler2).setVerbose(false).build();
+    assertEquals(testNumHandler2 * confQ, server.getMaxQueueSize());
   }
 
   @Test
@@ -602,7 +627,7 @@ public class TestRPC extends TestRpcBase {
       } else {
         assertCounter("RpcAuthorizationSuccesses", 1L, rb);
       }
-      //since we don't have authentication turned ON, we should see 
+      //since we don't have authentication turned ON, we should see
       // 0 for the authentication successes and 0 for failure
       assertCounter("RpcAuthenticationFailures", 0L, rb);
       assertCounter("RpcAuthenticationSuccesses", 0L, rb);
@@ -680,6 +705,7 @@ public class TestRPC extends TestRpcBase {
     RPC.stopProxy(MockitoUtil.mockProtocol(TestProtocol.class));
   }
 
+  // PUTs #25
   @Test
   public void testStopProxy() throws IOException {
     RPC.setProtocolEngine(conf,
@@ -689,11 +715,14 @@ public class TestRPC extends TestRpcBase {
         StoppedProtocol.versionID, null, conf);
     StoppedInvocationHandler invocationHandler = (StoppedInvocationHandler)
         Proxy.getInvocationHandler(proxy);
-    assertEquals(0, invocationHandler.getCloseCalled());
-    RPC.stopProxy(proxy);
-    assertEquals(1, invocationHandler.getCloseCalled());
+    for(int i=0;i<numberOfStopProxy;i++) {
+      RPC.stopProxy(proxy);
+    }
+    assertEquals(numberOfStopProxy, invocationHandler.getCloseCalled());
   }
 
+  // Potential Bug #3 :- test failure  -> java.lang.ClassCastException: org.apache.hadoop.ipc.WritableRpcEngine$Invoker
+  // cannot be cast to org.apache.hadoop.ipc.TestRPC$StoppedInvocationHandler
   @Test
   public void testWrappedStopProxy() throws IOException {
     StoppedProtocol wrappedProxy = RPC.getProxy(StoppedProtocol.class,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoWindows.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoWindows.java
@@ -19,8 +19,15 @@
 package org.apache.hadoop.util;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+@RunWith(Enclosed.class)
 public class TestSysInfoWindows {
 
 
@@ -43,25 +50,63 @@ public class TestSysInfoWindows {
     }
   }
 
+  @RunWith(Parameterized.class)
+  public static class TheParameterizedPart {
+  static final String COMMA = ",";
+
+  @Parameterized.Parameter(value = 0)
+  public long virtualMemorySize;
+  @Parameterized.Parameter(value = 1)
+  public long physicalMemorySize;
+  @Parameterized.Parameter(value = 2)
+  public long availableVirtualMemorySize;
+  @Parameterized.Parameter(value = 3)
+  public long availablePhysicalMemorySize;
+  @Parameterized.Parameter(value = 4)
+  public int numProcessors;
+  @Parameterized.Parameter(value = 5)
+  public long cpuFrequency;
+  @Parameterized.Parameter(value = 6)
+  public long cumulativeCpuTime;
+  @Parameterized.Parameter(value = 7)
+  public long storageBytesRead;
+  @Parameterized.Parameter(value = 8)
+  public long storageBytesWritten;
+  @Parameterized.Parameter(value = 9)
+  public long networkBytesRead;
+  @Parameterized.Parameter(value = 10)
+  public long networkBytesWritten;
+
+  @Parameterized.Parameters
+  public static Collection<Object> testData() {
+    Object[][] data = new Object[][] { {17177038848L,8589467648L,15232745472L,6400417792L,1,2805000L,6261812L,1234567L,2345678L,3456789L,4567890L},
+            {17177038848L,8589467648L,15232745472L,6400417792L,12,2805000L,6261812L,1234567L,2345678L,3456789L,4567890L},
+    };
+    return Arrays.asList(data);
+  }
+
+  // PUTs #29
   @Test(timeout = 10000)
   public void parseSystemInfoString() {
     SysInfoWindowsMock tester = new SysInfoWindowsMock();
     tester.setSysinfoString(
-        "17177038848,8589467648,15232745472,6400417792,1,2805000,6261812," +
-        "1234567,2345678,3456789,4567890\r\n");
+            virtualMemorySize + COMMA + physicalMemorySize + COMMA + availableVirtualMemorySize + COMMA +
+             availablePhysicalMemorySize + COMMA + numProcessors + COMMA + cpuFrequency + COMMA + cumulativeCpuTime +
+             COMMA + storageBytesRead + COMMA + storageBytesWritten + COMMA + networkBytesRead + COMMA +
+             networkBytesWritten + "\r\n");
     // info str derived from windows shell command has \r\n termination
-    assertEquals(17177038848L, tester.getVirtualMemorySize());
-    assertEquals(8589467648L, tester.getPhysicalMemorySize());
-    assertEquals(15232745472L, tester.getAvailableVirtualMemorySize());
-    assertEquals(6400417792L, tester.getAvailablePhysicalMemorySize());
-    assertEquals(1, tester.getNumProcessors());
-    assertEquals(1, tester.getNumCores());
-    assertEquals(2805000L, tester.getCpuFrequency());
-    assertEquals(6261812L, tester.getCumulativeCpuTime());
-    assertEquals(1234567L, tester.getStorageBytesRead());
-    assertEquals(2345678L, tester.getStorageBytesWritten());
-    assertEquals(3456789L, tester.getNetworkBytesRead());
-    assertEquals(4567890L, tester.getNetworkBytesWritten());
+    assertEquals(virtualMemorySize, tester.getVirtualMemorySize());
+    assertEquals(physicalMemorySize, tester.getPhysicalMemorySize());
+    assertEquals(availableVirtualMemorySize, tester.getAvailableVirtualMemorySize());
+    assertEquals(availablePhysicalMemorySize, tester.getAvailablePhysicalMemorySize());
+    assertEquals(numProcessors, tester.getNumProcessors());
+    assertEquals(numProcessors, tester.getNumCores());
+    assertEquals(cpuFrequency, tester.getCpuFrequency());
+    assertEquals(cumulativeCpuTime, tester.getCumulativeCpuTime());
+    assertEquals(storageBytesRead, tester.getStorageBytesRead());
+    assertEquals(storageBytesWritten, tester.getStorageBytesWritten());
+    assertEquals(networkBytesRead, tester.getNetworkBytesRead());
+    assertEquals(networkBytesWritten, tester.getNetworkBytesWritten());
     // undef on first call
     assertEquals((float)CpuTimeTracker.UNAVAILABLE,
         tester.getCpuUsagePercentage(), 0.0);
@@ -69,27 +114,32 @@ public class TestSysInfoWindows {
         tester.getNumVCoresUsed(), 0.0);
   }
 
+  // PUTs #30
   @Test(timeout = 10000)
   public void refreshAndCpuUsage() throws InterruptedException {
     SysInfoWindowsMock tester = new SysInfoWindowsMock();
     tester.setSysinfoString(
-        "17177038848,8589467648,15232745472,6400417792,1,2805000,6261812," +
-        "1234567,2345678,3456789,4567890\r\n");
+            virtualMemorySize + COMMA + physicalMemorySize + COMMA + availableVirtualMemorySize + COMMA +
+            availablePhysicalMemorySize + COMMA + numProcessors + COMMA + cpuFrequency + COMMA + cumulativeCpuTime +
+            COMMA + storageBytesRead + COMMA + storageBytesWritten + COMMA + networkBytesRead + COMMA +
+            networkBytesWritten + "\r\n");
     // info str derived from windows shell command has \r\n termination
     tester.getAvailablePhysicalMemorySize();
     // verify information has been refreshed
-    assertEquals(6400417792L, tester.getAvailablePhysicalMemorySize());
+    assertEquals(availablePhysicalMemorySize, tester.getAvailablePhysicalMemorySize());
     assertEquals((float)CpuTimeTracker.UNAVAILABLE,
         tester.getCpuUsagePercentage(), 0.0);
     assertEquals((float)CpuTimeTracker.UNAVAILABLE,
         tester.getNumVCoresUsed(), 0.0);
 
     tester.setSysinfoString(
-        "17177038848,8589467648,15232745472,5400417792,1,2805000,6263012," +
-        "1234567,2345678,3456789,4567890\r\n");
+            virtualMemorySize + COMMA + physicalMemorySize + COMMA + availableVirtualMemorySize + COMMA +
+            (availablePhysicalMemorySize - 1000000000) + COMMA + numProcessors + COMMA + cpuFrequency + COMMA +
+            (cumulativeCpuTime + 1200) + COMMA + storageBytesRead + COMMA + storageBytesWritten + COMMA +
+            networkBytesRead + COMMA + networkBytesWritten + "\r\n");
     tester.getAvailablePhysicalMemorySize();
     // verify information has not been refreshed
-    assertEquals(6400417792L, tester.getAvailablePhysicalMemorySize());
+    assertEquals(availablePhysicalMemorySize, tester.getAvailablePhysicalMemorySize());
     assertEquals((float)CpuTimeTracker.UNAVAILABLE,
         tester.getCpuUsagePercentage(), 0.0);
     assertEquals((float)CpuTimeTracker.UNAVAILABLE,
@@ -99,15 +149,18 @@ public class TestSysInfoWindows {
     tester.advance(SysInfoWindows.REFRESH_INTERVAL_MS + 1);
 
     // verify information has been refreshed
-    assertEquals(5400417792L, tester.getAvailablePhysicalMemorySize());
-    assertEquals((6263012 - 6261812) * 100F /
-                 (SysInfoWindows.REFRESH_INTERVAL_MS + 1f) / 1,
+    assertEquals(availablePhysicalMemorySize - 1000000000, tester.getAvailablePhysicalMemorySize());
+    assertEquals((1200) * 100F /
+                 (SysInfoWindows.REFRESH_INTERVAL_MS + 1f) / numProcessors,
                  tester.getCpuUsagePercentage(), 0.0);
-    assertEquals((6263012 - 6261812) /
+    assertEquals((1200) /
                  (SysInfoWindows.REFRESH_INTERVAL_MS + 1f) / 1,
                  tester.getNumVCoresUsed(), 0.0);
   }
+  }
 
+  public static class NotParameterizedPart {
+  // Can Be Removed #2, covered in PUTs #30
   @Test(timeout = 10000)
   public void refreshAndCpuUsageMulticore() throws InterruptedException {
     // test with 12 cores
@@ -151,5 +204,5 @@ public class TestSysInfoWindows {
     // call a method to refresh values
     tester.getAvailablePhysicalMemorySize();
   }
-
+  }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
@@ -22,19 +22,36 @@ import org.junit.Assert;
 import org.apache.hadoop.nfs.NfsTime;
 import org.apache.hadoop.oncrpc.XDR;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class TestNfsTime {
+
+  @Parameterized.Parameter(value = 0)
+  public int milliseconds;
+
+  @Parameterized.Parameters
+  public static Collection<Object> testMilliSeconds() {
+    Object[] data = new Object[] {0, -1, -101000, 1001, 1000, 999999999, -4567654};
+    return Arrays.asList(data);
+  }
+
+  // PUTs #17
   @Test
   public void testConstructor() {
-    NfsTime nfstime = new NfsTime(1001);
-    Assert.assertEquals(1, nfstime.getSeconds());
-    Assert.assertEquals(1000000, nfstime.getNseconds());
+    NfsTime nfstime = new NfsTime(milliseconds);
+    Assert.assertEquals(milliseconds/1000, nfstime.getSeconds());
+    Assert.assertEquals((milliseconds - (milliseconds/1000)*1000) * 1000000, nfstime.getNseconds());
   }
-  
+  // PUTs #18
   @Test
   public void testSerializeDeserialize() {
     // Serialize NfsTime
-    NfsTime t1 = new NfsTime(1001);
+    NfsTime t1 = new NfsTime(milliseconds);
     XDR xdr = new XDR();
     t1.serialize(xdr);
     


### PR DESCRIPTION
This PR has:- 
31 Unit tests retrofitted, selected individually via assert equal statements
**Test Parameterised** :- **30** (PUTs #)
**Bugs found** :- **4** (Potential Bug #) 
**New Test Added** :- **1** (CUTs #)
**Classes Covered** :- **9**
**Old tests which can be removed** after parameterisation :- **2** (Can be removed #) -> _We can find / modify tests to make more of these if we are interested, I wasn't deliberately looking for them and still found 2._

In many places, I have created two new classes inside the test class, using `@RunWith(Enclosed.class)` to segregate parameterized and non-parameterized tests. If we use `@RunWith(Parameterized.class)` directly in a class, then all the tests, even the non-parameterized ones, would run multiple times. 
This approach worked fine, but in some places, it required changing the ordering of tests; please bare with such scenarios until I try to find a way out. Also, indentation is deliberately not appropriately done for such cases to make the PR easy to perceive. Once I get the green flag will update it.
