### PR TITLE
HADOOP-JIRA_ID. Fixed ArrayIndexOutOfBoundsException in class DefaultStringifier

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -161,7 +161,7 @@ public class DefaultStringifier<T> implements Stringifier<T> {
     if (items.length == 0) {
       conf.set(keyName, "");
       return;
-     }
+    }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -159,10 +159,6 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
-    if (items == null) {
-      conf.set(keyName, "");
-      throw new NullPointerException();
-    }
     if (items.length == 0) {
       conf.set(keyName, "");
       throw new IndexOutOfBoundsException();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -158,6 +158,10 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
+    if (items.length == 0) {
+         conf.set(keyName, "");
+         return;
+     }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -159,7 +159,6 @@ public class DefaultStringifier<T> implements Stringifier<T> {
       String keyName) throws IOException {
 
     if (items.length == 0) {
-      conf.set(keyName, "");
       throw new IndexOutOfBoundsException();
     }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -151,6 +151,7 @@ public class DefaultStringifier<T> implements Stringifier<T> {
    * @param conf the configuration to use 
    * @param items the objects to be stored
    * @param keyName the name of the key to use
+   * @throws NullPointerException if the items array is null
    * @throws IndexOutOfBoundsException if the items array is empty
    * @throws IOException : forwards Exceptions from the underlying 
    * {@link Serialization} classes.         
@@ -158,6 +159,10 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
+    if (items == null) {
+      conf.set(keyName, "");
+      throw new NullPointerException();
+    }
     if (items.length == 0) {
       conf.set(keyName, "");
       throw new IndexOutOfBoundsException();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -151,7 +151,6 @@ public class DefaultStringifier<T> implements Stringifier<T> {
    * @param conf the configuration to use 
    * @param items the objects to be stored
    * @param keyName the name of the key to use
-   * @throws NullPointerException if the items array is null
    * @throws IndexOutOfBoundsException if the items array is empty
    * @throws IOException : forwards Exceptions from the underlying 
    * {@link Serialization} classes.         

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -158,7 +158,7 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
-    if (items.length == 0) {
+    if (items == null || items.length == 0) {
       conf.set(keyName, "");
       return;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -158,9 +158,9 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
-    if (items == null || items.length == 0) {
+    if (items.length == 0) {
       conf.set(keyName, "");
-      return;
+      throw new IndexOutOfBoundsException();
     }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -159,8 +159,8 @@ public class DefaultStringifier<T> implements Stringifier<T> {
       String keyName) throws IOException {
 
     if (items.length == 0) {
-         conf.set(keyName, "");
-         return;
+      conf.set(keyName, "");
+      return;
      }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class TestDefaultStringifier {
 
@@ -99,7 +99,7 @@ public class TestDefaultStringifier {
   }
 
   @Test
-  public void testStoreLoadArray() throws IOException {
+  public void testStoreLoadArray() throws Exception {
     LOG.info("Testing DefaultStringifier#storeArray() and #loadArray()");
     conf.set("io.serializations", "org.apache.hadoop.io.serializer.JavaSerialization");
 
@@ -108,12 +108,8 @@ public class TestDefaultStringifier {
     Integer[] array = new Integer[] {1,2,3,4,5};
 
     
-    try {
-      DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
-      fail("Should have thrown an IndexOutOfBoundsException");
-    } catch (IndexOutOfBoundsException e) {
-      // pass
-    }
+    intercept(IndexOutOfBoundsException.class, () ->
+        DefaultStringifier.storeArray(conf, new Integer[] {}, keyName));
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,8 +107,12 @@ public class TestDefaultStringifier {
 
     Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
 
-    // storeArray failed for empty array
-    DefaultStringifier.storeArray(conf, emptyArray, keyName);
+    try {
+      DefaultStringifier.storeArray(conf, emptyArray, keyName);
+      Assert.fail("Should have thrown an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException e) {
+      // pass
+    }
     assertEquals(0
         , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
     DefaultStringifier.storeArray(conf, array, keyName);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -114,8 +114,6 @@ public class TestDefaultStringifier {
     } catch (IndexOutOfBoundsException e) {
       // pass
     }
-    assertEquals(0
-        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -107,6 +107,7 @@ public class TestDefaultStringifier {
     Integer[] array = new Integer[] {1,2,3,4,5};
     Integer[] emptyArray = new Integer[] {};
 
+
     DefaultStringifier.storeArray(conf, emptyArray, keyName);
     DefaultStringifier.storeArray(conf, array, keyName);
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -108,6 +108,15 @@ public class TestDefaultStringifier {
     Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
 
     try {
+      DefaultStringifier.storeArray(conf, null, keyName);
+      Assert.fail("Should have thrown a NullPointerException");
+    } catch (NullPointerException e) {
+      // pass
+    }
+    assertEquals(0
+        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
+
+    try {
       DefaultStringifier.storeArray(conf, emptyArray, keyName);
       Assert.fail("Should have thrown an IndexOutOfBoundsException");
     } catch (IndexOutOfBoundsException e) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -105,19 +105,10 @@ public class TestDefaultStringifier {
 
     String keyName = "test.defaultstringifier.key2";
 
-    Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
+    Integer[] array = new Integer[] {1,2,3,4,5};
 
     try {
-      DefaultStringifier.storeArray(conf, null, keyName);
-      Assert.fail("Should have thrown a NullPointerException");
-    } catch (NullPointerException e) {
-      // pass
-    }
-    assertEquals(0
-        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
-
-    try {
-      DefaultStringifier.storeArray(conf, emptyArray, keyName);
+      DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
       Assert.fail("Should have thrown an IndexOutOfBoundsException");
     } catch (IndexOutOfBoundsException e) {
       // pass

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -104,11 +104,10 @@ public class TestDefaultStringifier {
 
     String keyName = "test.defaultstringifier.key2";
 
-    Integer[] array = new Integer[] {1,2,3,4,5};
-    Integer[] emptyArray = new Integer[] {};
+    Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
 
 
-    DefaultStringifier.storeArray(conf, emptyArray, keyName);
+    DefaultStringifier.storeArray(conf, emptyArray, keyName); // storeArray failed for empty array
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -107,6 +107,7 @@ public class TestDefaultStringifier {
 
     Integer[] array = new Integer[] {1,2,3,4,5};
 
+    
     try {
       DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
       Assert.fail("Should have thrown an IndexOutOfBoundsException");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -105,8 +105,9 @@ public class TestDefaultStringifier {
     String keyName = "test.defaultstringifier.key2";
 
     Integer[] array = new Integer[] {1,2,3,4,5};
+    Integer[] emptyArray = new Integer[] {};
 
-
+    DefaultStringifier.storeArray(conf, emptyArray, keyName);
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -22,12 +22,13 @@ import java.io.IOException;
 import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestDefaultStringifier {
 
@@ -110,7 +111,7 @@ public class TestDefaultStringifier {
     
     try {
       DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
-      Assert.fail("Should have thrown an IndexOutOfBoundsException");
+      fail("Should have thrown an IndexOutOfBoundsException");
     } catch (IndexOutOfBoundsException e) {
       // pass
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -108,6 +108,8 @@ public class TestDefaultStringifier {
 
 
     DefaultStringifier.storeArray(conf, emptyArray, keyName); // storeArray failed for empty array
+    assertEquals(0
+        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -106,8 +106,8 @@ public class TestDefaultStringifier {
 
     Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
 
-
-    DefaultStringifier.storeArray(conf, emptyArray, keyName); // storeArray failed for empty array
+    // storeArray failed for empty array
+    DefaultStringifier.storeArray(conf, emptyArray, keyName);
     assertEquals(0
         , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
     DefaultStringifier.storeArray(conf, array, keyName);


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-XXXXX](https://docs.google.com/document/d/1gdtUjOqtE-cJKjJUgbg2D_fJsq-2sv21wLKgqSjUHDI/edit?usp=sharing)
Todo:- link actual Jira Ticket

### How was this patch tested?

Modified an existing unit test `testStoreLoadArray` of test class `TestDefaultStringifier` to verify.




### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?