### PR TITLE
HADOOP-JIRA_ID. Fixed an unhandled NullPointerException in class KeyProvider

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -648,7 +648,7 @@ public abstract class KeyProvider implements Closeable {
   public static String getBaseName(String versionName) throws IOException {
     if (versionName == null) {
       throw new IOException("Null string found in key path");
-     }
+    }
     int div = versionName.lastIndexOf('@');
     if (div == -1) {
       throw new IOException("No version in key path " + versionName);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -639,13 +639,16 @@ public abstract class KeyProvider implements Closeable {
   public abstract void flush() throws IOException;
 
   /**
-   * Split the versionName in to a base name. Converts "/aaa/bbb/3" to
+   * Split the versionName in to a base name. Converts "/aaa/bbb@3" to
    * "/aaa/bbb".
    * @param versionName the version name to split
    * @return the base name of the key
    * @throws IOException raised on errors performing I/O.
    */
   public static String getBaseName(String versionName) throws IOException {
+    if (versionName == null) {
+       throw new IOException("Null value found in versionName");
+     }
     int div = versionName.lastIndexOf('@');
     if (div == -1) {
       throw new IOException("No version in key path " + versionName);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -647,7 +647,7 @@ public abstract class KeyProvider implements Closeable {
    */
   public static String getBaseName(String versionName) throws IOException {
     if (versionName == null) {
-       throw new IOException("Null value found in versionName");
+      throw new IOException("Null value found in versionName");
      }
     int div = versionName.lastIndexOf('@');
     if (div == -1) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -646,8 +646,8 @@ public abstract class KeyProvider implements Closeable {
    * @throws IOException raised on errors performing I/O.
    */
   public static String getBaseName(String versionName) throws IOException {
-    if (versionName == null) {
-      throw new IOException("Null string found in key path");
+    if (!Objects.nonNull(versionName)) {
+      throw new NullPointerException("key path variable versionName found null");
     }
     int div = versionName.lastIndexOf('@');
     if (div == -1) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -647,7 +647,7 @@ public abstract class KeyProvider implements Closeable {
    */
   public static String getBaseName(String versionName) throws IOException {
     if (versionName == null) {
-      throw new IOException("Null value found in versionName");
+      throw new IOException("Null string found in key path");
      }
     int div = versionName.lastIndexOf('@');
     if (div == -1) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -62,12 +63,8 @@ public class TestKeyProvider {
     } catch (IOException e) {
       assertTrue(true);
     }
-    try {
-      KeyProvider.getBaseName(null);
-      assertTrue("should have thrown", false);
-    } catch (IOException e) {
-      assertTrue(true);
-    }
+    intercept(NullPointerException.class, () ->
+        KeyProvider.getBaseName(null));
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
@@ -64,7 +64,7 @@ public class TestKeyProvider {
     }
     try {
       KeyProvider.getBaseName(null);
-      assertTrue("should have thrown an IOException", false);
+      assertTrue("should have thrown", false);
     } catch (IOException e) {
       assertTrue(true);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
@@ -62,6 +62,12 @@ public class TestKeyProvider {
     } catch (IOException e) {
       assertTrue(true);
     }
+    try {
+      KeyProvider.getBaseName(null);
+      assertTrue("should have thrown an IOException", false);
+    } catch (IOException e) {
+      assertTrue(true);
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-XXXXX](https://docs.google.com/document/d/1wQE3YUTYGw8WJhJHrAoqGLfkGEc9TImvm8IF8Oh0cKc/edit?usp=sharing)
Todo:- link actual Jira Ticket 

### How was this patch tested?
Modified an existing unit test `testParseVersionName` of test class `TestKeyProvider` to verify.



### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
