### PR TITLE
HADOOP-JIRA_ID. Fixed -ve data and throughput values in an output of class RawErasureCoderBenchmark

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureCoderBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureCoderBenchmark.java
@@ -320,6 +320,7 @@ public final class RawErasureCoderBenchmark {
     private ByteBuffer[] decodeInputs = new ByteBuffer[NUM_ALL_UNITS];
 
     public static void configure(int dataSizeMB, int chunkSizeKB) {
+      Preconditions.checkArgument(dataSizeMB > 0);
       chunkSize = chunkSizeKB * 1024;
       // buffer size needs to be a multiple of (numDataUnits * chunkSize)
       int round = (int) Math.round(

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.io.erasurecode.rawcoder;
 
 import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -33,6 +34,14 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.DUMMY_CODER, 2, 100, 1024);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.DUMMY_CODER, 5, 150, 100);
+
+    try {
+      RawErasureCoderBenchmark.performBench("decode",
+          RawErasureCoderBenchmark.CODER.DUMMY_CODER, 5, -150, 100);
+      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
+    } catch (IllegalArgumentException e) {
+      Assert.assertTrue(true);
+    }
   }
 
   @Test
@@ -42,6 +51,13 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 2, 80, 200);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 5, 300, 350);
+    try {
+      RawErasureCoderBenchmark.performBench("decode",
+          RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 5, -300, 350);
+      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
+    } catch (IllegalArgumentException e) {
+      Assert.assertTrue(true);
+    }
   }
 
   @Test
@@ -51,6 +67,14 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.RS_CODER, 3, 200, 200);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.RS_CODER, 4, 135, 20);
+
+    try {
+      RawErasureCoderBenchmark.performBench("decode",
+          RawErasureCoderBenchmark.CODER.RS_CODER, 4, -135, 20);
+      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
+    } catch (IllegalArgumentException e) {
+      Assert.assertTrue(true);
+    }
   }
 
   @Test
@@ -61,5 +85,13 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.ISAL_CODER, 5, 300, 64);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.ISAL_CODER, 6, 200, 128);
+
+    try {
+      RawErasureCoderBenchmark.performBench("decode",
+          RawErasureCoderBenchmark.CODER.ISAL_CODER, 6, -200, 128);
+      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
+    } catch (IllegalArgumentException e) {
+      Assert.assertTrue(true);
+    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
@@ -38,9 +38,9 @@ public class TestRawErasureCoderBenchmark {
     try {
       RawErasureCoderBenchmark.performBench("decode",
           RawErasureCoderBenchmark.CODER.DUMMY_CODER, 5, -150, 100);
-      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
+      Assert.fail("should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(true);
+      // intentionally swallow exception
     }
   }
 
@@ -51,13 +51,6 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 2, 80, 200);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 5, 300, 350);
-    try {
-      RawErasureCoderBenchmark.performBench("decode",
-          RawErasureCoderBenchmark.CODER.LEGACY_RS_CODER, 5, -300, 350);
-      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(true);
-    }
   }
 
   @Test
@@ -67,14 +60,6 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.RS_CODER, 3, 200, 200);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.RS_CODER, 4, 135, 20);
-
-    try {
-      RawErasureCoderBenchmark.performBench("decode",
-          RawErasureCoderBenchmark.CODER.RS_CODER, 4, -135, 20);
-      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(true);
-    }
   }
 
   @Test
@@ -85,13 +70,5 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.ISAL_CODER, 5, 300, 64);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.ISAL_CODER, 6, 200, 128);
-
-    try {
-      RawErasureCoderBenchmark.performBench("decode",
-          RawErasureCoderBenchmark.CODER.ISAL_CODER, 6, -200, 128);
-      Assert.assertTrue("should have thrown an IllegalArgumentException", false);
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(true);
-    }
   }
 }


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-XXXXX](https://docs.google.com/document/d/14lJ7DESSBpJ7U5_dHCJJungAXAB036z8S23uVTsyWmI/edit?usp=sharing)
Todo:- link actual Jira Ticket

### How was this patch tested?
Modified an existing unit test `testDummyCoder` of test class `TestRawErasureCoderBenchmark` to verify.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

